### PR TITLE
Added support for Windows 7

### DIFF
--- a/assets/ucc
+++ b/assets/ucc
@@ -18,6 +18,9 @@ VERSION=1.0 #stable-eol
 cd ..
 root="$(pwd)"
 
+#For Microsoft Windows 7 or below
+#ROOT=" <PATH TO ACTUAL WORKSPACE FOLDER>  "
+
 function show_help(){
 	echo -e "Usage: ucc [option] [argument]\n"
 	echo -e "ucc --build <filename>: builds <filename> from the sources folder.\n"
@@ -99,7 +102,7 @@ case "$#" in
 				cp $root/builds/$2 $root/files/RUN.EXE
 				cp $root/BIN/EGAVGA.BGI $root/files/
 				echo -e "INFO: Executing DOS file $2"
-				$root/assets/dosbox -noconsole -c MOUNT\ C\ \"${root}\" -c C: -c cd\ files -c RUN -c exit
+				$root/assets/dosbox -noconsole -c MOUNT\ C\ "$ROOT" -c C: -c cd\ files -c RUN -c exit
 				rm $root/files/RUN.EXE
 				rm $root/files/EGAVGA.BGI
 			;;

--- a/assets/ucc
+++ b/assets/ucc
@@ -16,10 +16,9 @@
 
 VERSION=1.0 #stable-eol
 cd ..
-root="$(pwd)"
 
 #For Microsoft Windows 7 or below
-#ROOT=" <PATH TO ACTUAL WORKSPACE FOLDER>  "
+#root="  <PATH TO ACTUAL WORKSPACE FOLDER>  "
 
 function show_help(){
 	echo -e "Usage: ucc [option] [argument]\n"
@@ -102,7 +101,7 @@ case "$#" in
 				cp $root/builds/$2 $root/files/RUN.EXE
 				cp $root/BIN/EGAVGA.BGI $root/files/
 				echo -e "INFO: Executing DOS file $2"
-				$root/assets/dosbox -noconsole -c MOUNT\ C\ "$ROOT" -c C: -c cd\ files -c RUN -c exit
+				$root/assets/dosbox -noconsole -c MOUNT\ C\ "$root" -c C: -c cd\ files -c RUN -c exit
 				rm $root/files/RUN.EXE
 				rm $root/files/EGAVGA.BGI
 			;;


### PR DESCRIPTION
Made another variable called "ROOT" which contains the actual path to the workspace folder. This is different from the existing workspaceFolder variable "root" as it uses ```pwd``` to get the current path.

Making these changes helps successfully mounting C drive to DOSBox and then executing the built .EXE executable file.